### PR TITLE
SquareRoot() 함수에 음수를 매개변수로 전달시 NaN을 리턴하는 현상 수정

### DIFF
--- a/MySmallBasic/src/com/coducation/smallbasic/lib/Math.java
+++ b/MySmallBasic/src/com/coducation/smallbasic/lib/Math.java
@@ -571,6 +571,8 @@ public class Math {
 
 			throw new InterpretException("SquareRoot : Unexpected # of args: " + args.size());
 
+		if (dbl_arg < 0) return new DoubleV(0);
+		
 		return new DoubleV(java.lang.Math.sqrt(dbl_arg));
 
 	}

--- a/MySmallBasic/src/com/coducation/smallbasic/lib/TextWindow.java
+++ b/MySmallBasic/src/com/coducation/smallbasic/lib/TextWindow.java
@@ -180,7 +180,7 @@ public class TextWindow {
 			
 			if (ForegroundColor instanceof StrV) {
 				
-				v = ((StrV)ForegroundColor).getValue();
+				v = ((StrV)ForegroundColor).getValue().toUpperCase();
 				
 			} else
 				
@@ -195,7 +195,7 @@ public class TextWindow {
 			
 			if (BackgroundColor instanceof StrV) {
 				
-				v = ((StrV)BackgroundColor).getValue();
+				v = ((StrV)BackgroundColor).getValue().toUpperCase();
 				
 			} else
 				


### PR DESCRIPTION
module_equation.sb 테스트 중 허수를 해로 가지는 이차방정식인 경우로 실행 시,
NaN을 결과로 출력하는 현상이 발견되어 정상적으로 0을 리턴할 수 있도록 수정하였습니다.