### PR TITLE
config 속성 변경 후 재실행

### DIFF
--- a/MySmallBasic/.classpath
+++ b/MySmallBasic/.classpath
@@ -26,6 +26,6 @@
 	<classpathentry kind="lib" path="lib/jfugue-5.0.9.jar"/>
 	<classpathentry kind="lib" path="lib/restfb-2.4.0.jar"/>
 	<classpathentry kind="lib" path="lib/sqlite-jdbc-3.21.0.jar"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/SmallBasicText"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/SmallBasicDataCollection"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/MySmallBasic/.classpath
+++ b/MySmallBasic/.classpath
@@ -27,5 +27,6 @@
 	<classpathentry kind="lib" path="lib/restfb-2.4.0.jar"/>
 	<classpathentry kind="lib" path="lib/sqlite-jdbc-3.21.0.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/SmallBasicDataCollection"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/YapbConfigManager"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/MySmallBasic/src/com/coducation/smallbasic/gui/JScrollPopupMenu.java
+++ b/MySmallBasic/src/com/coducation/smallbasic/gui/JScrollPopupMenu.java
@@ -23,6 +23,8 @@ public class JScrollPopupMenu extends JPopupMenu {
     protected int maximumVisibleRows = 10;
     private int itemPosition = 11;
     private int focusMenuIndex = 0;
+    private int scrollbarMenuitemCount = 0;
+    private final int itemCount = itemPosition;
     
     public JScrollPopupMenu() {
         this(null);
@@ -49,7 +51,7 @@ public class JScrollPopupMenu extends JPopupMenu {
         
         addMenuKeyListener(new MenuKeyListener() {
 			public void menuKeyPressed(MenuKeyEvent event) {
-				int scrollBar_MaxValue = scrollBar.getComponentCount() * scrollBar.getHeight() / maximumVisibleRows;
+				int scrollBar_MaxValue = (scrollbarMenuitemCount - itemCount) * scrollBar.getHeight() / maximumVisibleRows;
 				int keyCode = event.getKeyCode();
 				
 				if(focusMenuIndex != 0) {
@@ -59,16 +61,15 @@ public class JScrollPopupMenu extends JPopupMenu {
 				
 				if( keyCode == KeyEvent.VK_UP) {
 					itemPosition++;
-					if(itemPosition >= 11) {
+					if(itemPosition >= itemCount) {
 						if(scrollBar.getValue() == 0) {
 							scrollBar.setValue(scrollBar_MaxValue);
-							if(itemPosition > 11) itemPosition = 1;
+							if(itemPosition > itemCount) itemPosition = 1;
 							else itemPosition = 0;
 						} else {
 							itemPosition = 9;
 							scrollBar.setValue(scrollBar.getValue() - scrollBar.getUnitIncrement());
 						}
-						
 						event.consume();
 					}
 				}
@@ -78,7 +79,7 @@ public class JScrollPopupMenu extends JPopupMenu {
 						if(scrollBar.getValue() == scrollBar_MaxValue) {
 							scrollBar.setValue(0);
 							if(itemPosition < 0) itemPosition = 10;
-							else itemPosition = 11;
+							else itemPosition = itemCount;
 							
 						} else {
 							itemPosition = 2;
@@ -130,6 +131,7 @@ public class JScrollPopupMenu extends JPopupMenu {
         if(maximumVisibleRows < getComponentCount()-1) {
             getScrollBar().setVisible(true);
         }
+        scrollbarMenuitemCount++;
     }
 
     public void remove(int index) {

--- a/MySmallBasic/src/com/coducation/smallbasic/gui/MySmallBasicSyntaxItems.java
+++ b/MySmallBasic/src/com/coducation/smallbasic/gui/MySmallBasicSyntaxItems.java
@@ -160,13 +160,14 @@ public class MySmallBasicSyntaxItems {
 									String pattern = null; 	// 정규식
 									String matcherName = null; // 정규식에 대한 문자열(ID, NUM, STR)
 									int inputAfterCursor = textAreaMaker.getTextArea().getCaretPosition();
-
+									
+									String modifiedStr = listStr; // 사용자가 ID 입력에 대해 ID를 입력했을 시를 대비한 문자열 수정 변수
 									
 									// 추가한 item에 ID, NUM, STR이 존재하는 동안 실행
 									while(flag && input != null) {
-										matcher_ID = Pattern.compile("ID").matcher(listStr);
-										matcher_NUM = Pattern.compile("NUM").matcher(listStr);
-										matcher_STR = Pattern.compile("STR").matcher(listStr);
+										matcher_ID = Pattern.compile("ID").matcher(modifiedStr);
+										matcher_NUM = Pattern.compile("NUM").matcher(modifiedStr);
+										matcher_STR = Pattern.compile("STR").matcher(modifiedStr);
 											
 										if(flag = matcher_ID.find()) {
 											matcherIdx = matcher_ID.start();
@@ -196,6 +197,7 @@ public class MySmallBasicSyntaxItems {
 													cursorPosition += matcherIdx;
 													textAreaMaker.getTextArea().replaceRange(input, cursorPosition, cursorPosition + matcherName.length());
 													listStr = listStr.replaceFirst(matcherName, input); // 수정된 문자열로 저장
+													modifiedStr = modifiedStr.replaceFirst(matcherName, input.toLowerCase()); // 사용자 입력문이 ID, NUM, STR과 겹치지 않도록 소문자로 변환하여 저장
 													break;
 												}
 												// 정규식에 맞지 않으면 재입력 요구 다이얼로그 출력

--- a/MySmallBasic/src/com/coducation/smallbasic/gui/MySmallBasicSyntaxItems.java
+++ b/MySmallBasic/src/com/coducation/smallbasic/gui/MySmallBasicSyntaxItems.java
@@ -76,12 +76,12 @@ public class MySmallBasicSyntaxItems {
 								list_temp = list.get(i);
 								list_temp = list_temp.replace("NT CRStmtCRs ", "Enter ");
 								list_temp = list_temp.replace("CR", "Enter ");
-								list_temp = list_temp.replaceAll("NT\\s[^\\s]*", "blank");
+								list_temp = list_temp.replaceAll(" NT\\s[^\\s]*", "blank");
 								
 								list_temp = list_temp.replaceAll("T ", "");
 								// 공백이 중복해서 나오면 제거
-								list_temp = list_temp.replaceAll("\\s+", "");
-								list_temp = list_temp.replace("Enter", " " + NEWLINE);
+								list_temp = list_temp.replaceAll("\\s+", " ");
+								list_temp = list_temp.replace("Enter ", "\n");
 								list_temp = list_temp.replaceAll("[\\s+]?[.][\\s+]?", ".");
 								// 커서를 Nonterminal 위치로 변경
 								int setcursor = list_temp.indexOf("blank");
@@ -107,11 +107,11 @@ public class MySmallBasicSyntaxItems {
 								list_temp = list_temp.replace("NT CRStmtCRs ", "Enter ");
 								list_temp = list_temp.replace("CR", "Enter ");
 								list_temp = list_temp.replaceAll("NT\\s[^\\s]*", "blank");
-								list_temp = list_temp.replaceAll("T ", "");
+								list_temp = list_temp.replaceAll(" T ", "");
 								
 								// 공백이 중복해서 나오면 제거
-								list_temp = list_temp.replaceAll("\\s+", "");
-								list_temp = list_temp.replace("Enter", " " + NEWLINE);
+								list_temp = list_temp.replaceAll("\\s+", " ");
+								list_temp = list_temp.replace("Enter ", "\n");
 								list_temp = list_temp.replaceAll("[\\s+]?[.][\\s+]?", ".");
 								
 								// 커서를 Nonterminal 위치로 변경

--- a/MySmallBasic/src/com/coducation/smallbasic/gui/MySmallBasicSyntaxItems.java
+++ b/MySmallBasic/src/com/coducation/smallbasic/gui/MySmallBasicSyntaxItems.java
@@ -20,6 +20,7 @@ import javax.swing.text.BadLocationException;
 import com.coducation.smallbasic.syncomp.SocketCommunication;
 
 public class MySmallBasicSyntaxItems {
+	public static final String NEWLINE = System.getProperty("line.separator");
 	private static JPanel contentPane;
 	private TextAreaMaker textAreaMaker;
 	private JPopupMenu popupmenu;
@@ -80,17 +81,17 @@ public class MySmallBasicSyntaxItems {
 							if(state_receive) {
 								// Popupmenu 이벤트 발생 시 textArea에 출력될 문자열
 								// Terminal, Nonterminal 치환
+								System.out.println(list.get(i));
 								list_temp = list.get(i);
-								list_temp = list_temp.replaceAll("CRStmtCRs", "Enter Enter");
-								list_temp = list_temp.replaceAll("CR", "Enter Enter");
+								list_temp = list_temp.replace("NT CRStmtCRs ", "Enter ");
+								list_temp = list_temp.replace("CR", "Enter ");
 								list_temp = list_temp.replaceAll("NT\\s(.*?) ", "blank");
 								list_temp = list_temp.replaceAll("T ", "");
 								// 공백이 중복해서 나오면 제거
 								list_temp = list_temp.replaceAll("\\s+", " ");
-								list_temp = list_temp.replace("Enter ", System.getProperty("line.separator"));
+								list_temp = list_temp.replace("Enter ", NEWLINE);
 								
-								list_temp = list_temp.replaceAll("[.] ", ".");
-								list_temp = list_temp.replaceAll(" [.]", ".");
+								list_temp = list_temp.replaceAll("\\s+[.]\\s+", ".");
 								// 커서를 Nonterminal 위치로 변경
 								int setcursor = list_temp.indexOf("blank");
 								list_temp = list_temp.replaceAll("blank", "");
@@ -99,8 +100,7 @@ public class MySmallBasicSyntaxItems {
 								list.set(i, list.get(i).replaceAll("NT ", "blank"));
 								list.set(i, list.get(i).replaceAll("T ", ""));
 								
-								list.set(i, list.get(i).replaceAll("[.] ", "."));
-								list.set(i, list.get(i).replaceAll(" [.]", "."));
+								list.set(i, list.get(i).replaceAll("\\s+[.]\\s+", "."));
 								
 								list.set(i, list.get(i).replaceAll("blank", ""));
 								
@@ -114,9 +114,10 @@ public class MySmallBasicSyntaxItems {
 							else {
 								// 서버로부터 문자열로 후보를 받아온다면
 								// "..."이 있으면 처음 "..." 위치로 커서 위치 변경
+								System.out.println(list.get(i));
 								list.set(i, list.get(i).replace("...", "blank"));
 								
-								list.set(i, list.get(i).replaceAll("\\s?+[.]\\s?+ ", "."));
+								list.set(i, list.get(i).replaceAll("[\\s+]?[.][\\s+]?", "."));
 								
 								int setcursor = list.get(i).indexOf("blank");
 								cursorList.add(setcursor); // 각 구문에 대한 커서 위치 저장
@@ -125,19 +126,18 @@ public class MySmallBasicSyntaxItems {
 								
 								menuitem = new JMenuItem(list.get(i));
 								
-								list.set(i, list.get(i).replaceAll("CRStmtCRs", System.getProperty("line.separator")));
-								list.set(i, list.get(i).replaceAll("CR", System.getProperty("line.separator")));
+								list.set(i, list.get(i).replaceAll("CRStmtCRs", NEWLINE));
+								list.set(i, list.get(i).replaceAll("CR", NEWLINE));
 								
 							}
 								
-							int stridx = list.get(i).length();
-								
-							String itemHeader = list.get(i).substring(0, stridx); // item action에 대한 추가할 문자열
+							String itemHeader = list.get(i); // item action에 대한 추가할 문자열
 							
 							menuitem.addActionListener(new ActionListener() {
 								public void actionPerformed(ActionEvent e) {
 									cursorPosition = textAreaMaker.getTextArea().getCaretPosition(); // 문자열 추가 전의 커서 위치
 									textAreaMaker.getTextArea().insert(itemHeader, position); // 커서 위치에 item 추가
+									System.out.println("선택한 구문 후보:" + itemHeader);
 									int listIndex = list.indexOf(itemHeader);
 									if(cursorList.get(listIndex) != -1) {
 										// 추가한 item에서 NT 위치에 커서를 재설정

--- a/MySmallBasic/src/com/coducation/smallbasic/gui/MySmallBasicSyntaxItems.java
+++ b/MySmallBasic/src/com/coducation/smallbasic/gui/MySmallBasicSyntaxItems.java
@@ -38,7 +38,9 @@ public class MySmallBasicSyntaxItems {
 	private Matcher matcher_NUM;
 	private Matcher matcher_STR;
 	
-	// textArea에 PopupMenu 추가 Tab 누를 시 popupmenu 출력
+	private boolean flag = false; // ctrl 키를 누르고 있는지에 대한 flag
+	
+	// textArea에 PopupMenu 추가 ctrl + spacebar 누를 시 popupmenu 출력
 	public MySmallBasicSyntaxItems(JPanel panel, TextAreaMaker textArea) {
 		this.contentPane = panel;
 		this.textAreaMaker = textArea;
@@ -49,7 +51,11 @@ public class MySmallBasicSyntaxItems {
 			public void keyPressed(KeyEvent e) {
 				int keyCode = e.getKeyCode();
 				
-				if(keyCode == KeyEvent.VK_TAB) {
+				if(keyCode == KeyEvent.VK_CONTROL) {
+					flag = true;
+				}
+				
+				if((keyCode == KeyEvent.VK_SPACE )&& flag) {
 					SC = new SocketCommunication(textAreaMaker.getTextArea());
 					isConnect = SC.getIsConnect();
 					
@@ -102,12 +108,12 @@ public class MySmallBasicSyntaxItems {
 							else {
 								// 서버로부터 문자열로 후보를 받아온다면
 								// "..."이 있으면 처음 "..." 위치로 커서 위치 변경
-								System.out.println(list.get(i));
+								// System.out.println(list.get(i));
 								list_temp = list.get(i);
 								list_temp = list_temp.replace("NT CRStmtCRs ", "Enter ");
 								list_temp = list_temp.replace("CR", "Enter ");
 								list_temp = list_temp.replaceAll("NT\\s[^\\s]*", "blank");
-								list_temp = list_temp.replaceAll(" T ", "");
+								list_temp = list_temp.replaceAll("T ", "");
 								
 								// 공백이 중복해서 나오면 제거
 								list_temp = list_temp.replaceAll("\\s+", " ");
@@ -231,11 +237,14 @@ public class MySmallBasicSyntaxItems {
 				int columnNum = 0;
 				int caretpos = 0;
 				int keyCode = e.getKeyCode();
-				if( isReceive && isConnect && (keyCode == KeyEvent.VK_TAB)) {
+				
+				if(keyCode == KeyEvent.VK_CONTROL) flag = false;
+				
+				if( isReceive && isConnect && (keyCode == KeyEvent.VK_SPACE) && flag) {
 					// 커서 위치를 원래 위치로 변경
 					try {
 					// tab키로 인한 공백 제거
-					textAreaMaker.getTextArea().replaceRange("", position, position+1);
+					//textAreaMaker.getTextArea().replaceRange("", position, position+1);
 			            
 			        caretpos = textAreaMaker.getTextArea().getCaretPosition();
 					}
@@ -255,9 +264,10 @@ public class MySmallBasicSyntaxItems {
 						scrollPopupmenu.show(textAreaMaker.getTextArea(), (int)rectangle.getX() + 43 , (int)rectangle.getY() + 20);
 					}
 					else {
-						// popupmenu가 나타날 위치 설정, tab키를 누른 위치
+						// popupmenu가 나타날 위치 설정, ctrl + spacebar를 누른 위치
 						scrollPopupmenu.show(textAreaMaker.getTextArea(), (int)rectangle.getX() + 3 , (int)rectangle.getY() + 20);
 					}
+					flag = false;
 				}
 			}
 		});

--- a/MySmallBasic/src/com/coducation/smallbasic/gui/MySmallBasicSyntaxItems.java
+++ b/MySmallBasic/src/com/coducation/smallbasic/gui/MySmallBasicSyntaxItems.java
@@ -65,17 +65,9 @@ public class MySmallBasicSyntaxItems {
 						ArrayList<String> list = SC.getList(); // 서버를 통해 받아온 후보 구문들
 						ArrayList<Integer> cursorList = new ArrayList<>(); // 후보 구문에 대한 각 커서 위치
 						
-						int i;
-						// 서버로부터 파싱 상태만 받아온다면 i = 0, 아니라면 i = 1
-						// 서버로부터 직접 구문 후보들을 받아올 때 첫 인덱스가 공백인 점을 고려
-						if(state_receive) i = 0;
-						else {
-							i = 1;
-							cursorList.add(0);
-						}
 						String list_temp;
 						// popupmenu에 문자열 추가
-						for(; i < list.size(); i++) {
+						for(int i = 0; i < list.size(); i++) {
 							// 만약 서버로부터 파싱 상태만 받아온다면
 							JMenuItem menuitem;
 							if(state_receive) {
@@ -85,13 +77,14 @@ public class MySmallBasicSyntaxItems {
 								list_temp = list.get(i);
 								list_temp = list_temp.replace("NT CRStmtCRs ", "Enter ");
 								list_temp = list_temp.replace("CR", "Enter ");
-								list_temp = list_temp.replaceAll("NT\\s(.*?) ", "blank");
+								list_temp = list_temp.replaceAll("NT\\s[^\\s]*", "blank");
+								
 								list_temp = list_temp.replaceAll("T ", "");
 								// 공백이 중복해서 나오면 제거
 								list_temp = list_temp.replaceAll("\\s+", " ");
 								list_temp = list_temp.replace("Enter ", NEWLINE);
 								
-								list_temp = list_temp.replaceAll("\\s+[.]\\s+", ".");
+								list_temp = list_temp.replaceAll("[\\s+]?[.][\\s+]?", ".");
 								// 커서를 Nonterminal 위치로 변경
 								int setcursor = list_temp.indexOf("blank");
 								list_temp = list_temp.replaceAll("blank", "");
@@ -100,7 +93,7 @@ public class MySmallBasicSyntaxItems {
 								list.set(i, list.get(i).replaceAll("NT ", "blank"));
 								list.set(i, list.get(i).replaceAll("T ", ""));
 								
-								list.set(i, list.get(i).replaceAll("\\s+[.]\\s+", "."));
+								list.set(i, list.get(i).replaceAll("[\\s+]?[.][\\s+]?", "."));
 								
 								list.set(i, list.get(i).replaceAll("blank", ""));
 								
@@ -137,7 +130,7 @@ public class MySmallBasicSyntaxItems {
 								public void actionPerformed(ActionEvent e) {
 									cursorPosition = textAreaMaker.getTextArea().getCaretPosition(); // 문자열 추가 전의 커서 위치
 									textAreaMaker.getTextArea().insert(itemHeader, position); // 커서 위치에 item 추가
-									System.out.println("선택한 구문 후보:" + itemHeader);
+									
 									int listIndex = list.indexOf(itemHeader);
 									if(cursorList.get(listIndex) != -1) {
 										// 추가한 item에서 NT 위치에 커서를 재설정
@@ -215,9 +208,10 @@ public class MySmallBasicSyntaxItems {
 									
 							}); // end ActionListener
 							popupmenu.add(menuitem);
-							scrollPopupmenu.addImpl(menuitem, scrollPopupmenu, i);
+							scrollPopupmenu.addImpl(menuitem, popupmenu, i);
 								
 						} // end for
+						
 						scrollPopupmenu.setComponentPopupMenu(popupmenu);
 						contentPane.add(popupmenu);
 					}

--- a/MySmallBasic/src/com/coducation/smallbasic/gui/MySmallBasicSyntaxItems.java
+++ b/MySmallBasic/src/com/coducation/smallbasic/gui/MySmallBasicSyntaxItems.java
@@ -72,7 +72,6 @@ public class MySmallBasicSyntaxItems {
 							JMenuItem menuitem;
 							if(state_receive) {
 								// Popupmenu 이벤트 발생 시 textArea에 출력될 문자열
-								// Terminal, Nonterminal 치환
 								System.out.println(list.get(i));
 								list_temp = list.get(i);
 								list_temp = list_temp.replace("NT CRStmtCRs ", "Enter ");
@@ -81,21 +80,17 @@ public class MySmallBasicSyntaxItems {
 								
 								list_temp = list_temp.replaceAll("T ", "");
 								// 공백이 중복해서 나오면 제거
-								list_temp = list_temp.replaceAll("\\s+", " ");
-								list_temp = list_temp.replace("Enter ", NEWLINE);
-								
+								list_temp = list_temp.replaceAll("\\s+", "");
+								list_temp = list_temp.replace("Enter", " " + NEWLINE);
 								list_temp = list_temp.replaceAll("[\\s+]?[.][\\s+]?", ".");
 								// 커서를 Nonterminal 위치로 변경
 								int setcursor = list_temp.indexOf("blank");
 								list_temp = list_temp.replaceAll("blank", "");
 								
 								// Popupmenu에 띄울 문자열
-								list.set(i, list.get(i).replaceAll("NT ", "blank"));
+								list.set(i, list.get(i).replaceAll("NT ", ""));
 								list.set(i, list.get(i).replaceAll("T ", ""));
-								
 								list.set(i, list.get(i).replaceAll("[\\s+]?[.][\\s+]?", "."));
-								
-								list.set(i, list.get(i).replaceAll("blank", ""));
 								
 								// popupmenu에 띄우는 문자열과 textArea에 띄우는 문자열을 다르게 설정함
 								menuitem = new JMenuItem(list.get(i));
@@ -108,20 +103,32 @@ public class MySmallBasicSyntaxItems {
 								// 서버로부터 문자열로 후보를 받아온다면
 								// "..."이 있으면 처음 "..." 위치로 커서 위치 변경
 								System.out.println(list.get(i));
-								list.set(i, list.get(i).replace("...", "blank"));
+								list_temp = list.get(i);
+								list_temp = list_temp.replace("NT CRStmtCRs ", "Enter ");
+								list_temp = list_temp.replace("CR", "Enter ");
+								list_temp = list_temp.replaceAll("NT\\s[^\\s]*", "blank");
+								list_temp = list_temp.replaceAll("T ", "");
 								
+								// 공백이 중복해서 나오면 제거
+								list_temp = list_temp.replaceAll("\\s+", "");
+								list_temp = list_temp.replace("Enter", " " + NEWLINE);
+								list_temp = list_temp.replaceAll("[\\s+]?[.][\\s+]?", ".");
+								
+								// 커서를 Nonterminal 위치로 변경
+								int setcursor = list_temp.indexOf("blank");
+								list_temp = list_temp.replaceAll("blank", "");
+								
+								// Popupmenu에 띄울 문자열
+								list.set(i, list.get(i).replaceAll("NT ", ""));
+								list.set(i, list.get(i).replaceAll("T ", ""));
 								list.set(i, list.get(i).replaceAll("[\\s+]?[.][\\s+]?", "."));
 								
-								int setcursor = list.get(i).indexOf("blank");
-								cursorList.add(setcursor); // 각 구문에 대한 커서 위치 저장
-								list.set(i, list.get(i).replaceAll("blank", ""));
-								list.set(i, list.get(i).replaceAll("\\s+", " "));
-								
+								// popupmenu에 띄우는 문자열과 textArea에 띄우는 문자열을 다르게 설정함
 								menuitem = new JMenuItem(list.get(i));
 								
-								list.set(i, list.get(i).replaceAll("CRStmtCRs", NEWLINE));
-								list.set(i, list.get(i).replaceAll("CR", NEWLINE));
+								list.set(i, list_temp);
 								
+								cursorList.add(setcursor);
 							}
 								
 							String itemHeader = list.get(i); // item action에 대한 추가할 문자열

--- a/MySmallBasic/src/com/coducation/smallbasic/syncomp/SocketCommunication.java
+++ b/MySmallBasic/src/com/coducation/smallbasic/syncomp/SocketCommunication.java
@@ -160,17 +160,15 @@ public class SocketCommunication {
 							}
 						}
 						
-						Comparator<Integer> comparator = Comparator.reverseOrder(); // 내림차순으로 정렬
-						// 키값 중복이 예상되므로 수정 필요
-						Map<Integer, ArrayList<String>> sortList = new TreeMap<>(comparator); // 정렬과 중복 확인 위해 map 사용
+						Map<ArrayList<String>, Integer> sortList = new HashMap<>(); // 정렬과 중복 확인 위해 map 사용
 						
 						ArrayList<Pair> dupCheckList = new ArrayList<Pair>(); // 파싱 상태에 대한 구문 후보 중복 체크용 리스트
 						dupCheckList = syntaxManager.searchForSyntaxCompletion(newStateList); // 전달받은 상태에 대한 후보 구문들을 리스트로 저장
 						
 						// list에 담겨있지 않은 구문 후보만 저장
 						for(Pair pair : dupCheckList) {
-							if(!sortList.containsValue(pair.getFirst())) {
-								sortList.put(pair.getSecond(), pair.getFirst());
+							if(!sortList.containsKey(pair.getFirst())) {
+								sortList.put(pair.getFirst(), pair.getSecond());
 							}
 						}
 						

--- a/MySmallBasic/src/com/coducation/smallbasic/syncomp/SocketCommunication.java
+++ b/MySmallBasic/src/com/coducation/smallbasic/syncomp/SocketCommunication.java
@@ -46,8 +46,8 @@ public class SocketCommunication {
 	
 	static {
 		try {
-			// smallbasic-program-list-yapb-data-colletion_results.txt 경로 파라미터로 전달
-			syntaxManager = new SyntaxCompletionDataManager("C:\\Users\\Hwangsooyeon\\git\\SmallBasicDataCollection\\data\\smallbasic-program-list-yapb-data-colletion_results.txt"); // 경로 넣어줘야 함
+			// smallbasic-program-list-yapb-data-colletion_results.txt 경로 파라미터로 전달/resource/GUI/open.png
+			syntaxManager = new SyntaxCompletionDataManager(System.getProperty("user.dir") + "/data/smallbasic-program-list-yapb-data-colletion_results.txt"); // 경로 넣어줘야 함
 		} catch (IOException e) {
 			System.out.println("Error: Load in SyntaxCompletionDataManager");
 			e.printStackTrace();
@@ -191,15 +191,8 @@ public class SocketCommunication {
 						
 						parsingList = syntaxManager.mapToArray(sortList); // map의 구문후보만을 뽑아서 arraylist로 반환
 						
-						// configFile의 collection 값 변경
-						/*
-						configData = configData.replaceAll(",", "," + System.lineSeparator());
-						configData = configData.replace("{", "{" + System.lineSeparator());
-						configData = configData.replaceAll("config_TABSTATE = True", "config_TABSTATE = False");
-						yapbManager.printConfigFile(configData);
-						*/
-						
-						configData = yapbManager.configConversion(configData, "False");
+						// configFile의 tabstate 값 변경
+						configData = yapbManager.configConversion(configData, "False", "True");
 						
 						accessServer1(host);
 						serverConnect(sendMessage, textArea);
@@ -226,12 +219,7 @@ public class SocketCommunication {
 					list = parsingList;
 					
 					// yapb.config 파일을 원래대로 돌려둔다.
-					/*
-					configData = configData.replaceAll("config_TABSTATE = False", "config_TABSTATE = True");
-					yapbManager.printConfigFile(configData);
-					*/
-					
-					configData = yapbManager.configConversion(configData, "True");
+					configData = yapbManager.configConversion(configData, "True", "False");
 				}
 				
 			} catch (IOException e2) {

--- a/MySmallBasic/src/com/coducation/smallbasic/syncomp/SocketCommunication.java
+++ b/MySmallBasic/src/com/coducation/smallbasic/syncomp/SocketCommunication.java
@@ -73,6 +73,7 @@ public class SocketCommunication {
 			String sendMessage = "" + textLength + " True";
 			
 			// 서버에게 텍스트 길이 전달
+			System.out.println("텍스트 길이 전달" + sendMessage);
 			output.print(sendMessage);
 			output.flush();
 			
@@ -81,6 +82,7 @@ public class SocketCommunication {
 
 			
 			// 다시 서버 접속, 커서 앞의 텍스트 보내기
+			System.out.println("커서 앞의 텍스트:");
 			accessServer1(host);
 			
 			output.print(message);
@@ -91,6 +93,7 @@ public class SocketCommunication {
 			
 			
 			// 서버 접속, 커서 뒤의 텍스트를 보낸다.
+			System.out.println("커서 뒤의 텍스트:");
 			accessServer1(host);
 			
 			message = textArea.getText();
@@ -121,9 +124,12 @@ public class SocketCommunication {
 						receiveMessage = receiveMessage.replace("white ", "");
 						messageStateIdx = receiveMessage.indexOf(" ") + 1;
 						subStr = receiveMessage.charAt(messageStateIdx); // 첫 공백을 기준으로 다음 문자를 뽑아낸다.
-						//state_receive = subStr.matches("\\d*");
 						state_receive = Character.isDigit(subStr); // 다음 문자가 숫자가 전달되었는지 확인(파싱 상태만 전달받았는지)
-						if(state_receive) state_list = receiveMessage.split(" "); // 파싱 상태를 전달받았다면 상태들을 뽑아온다.
+						
+						if(state_receive) {
+							receiveMessage = receiveMessage.replaceAll("Terminal ", "");
+							state_list = receiveMessage.split(" "); // 파싱 상태를 전달받았다면 상태들을 뽑아온다.
+						}
 					} else continue;
 						
 					// 이전 문자열이 공백이면 state 0을 반환
@@ -172,9 +178,13 @@ public class SocketCommunication {
 							}
 						}
 						
-						list = syntaxManager.mapToArray(sortList);
+						list = syntaxManager.mapToArray(sortList); // map의 구문후보만을 뽑아서 arraylist로 반환
 					}
 					else {
+						// 파싱상태 map과 같은 문자열 형식으로 list에 저장
+						receiveMessage = receiveMessage.replaceAll("Terminal", "T");
+						receiveMessage = receiveMessage.replaceAll("Nonterminal", "NT");
+						
 						list.add(receiveMessage);
 					}
 				} // while


### PR DESCRIPTION
1. 구문 후보 출력 시 개행 문자가 포함되는 후보의 경우 줄 마지막에 커서 이동이 되지 않는 오류 수정
2. popupmenu scroll 오류 수정
3. config 속성(TABSTATE, DISPLAY) 변경 후 서버 재실행 후 구문 후보 정렬
4. 사용자 keyEvent tab -> ctrl+space로 변경
5. 사용자가 ID, STR, NUM 그대로 입력 시 커서 위치를 못 찾던 버그 수정


서버 실행하여 구문후보를 얻어오는데 필요한 파일들(config, exe, action, mygrammer ...)
MySmallBasic 프로젝트 경로로 이동 필요
(해당 파일들의 경로 이동 수정사항은 commit에 포함시키지 않았음) 